### PR TITLE
Fix failure to parse single-season Series

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ This directory contains the following GENERATED files:
   the Stage 2 notebook but not needed for the current scripts. However,
   it does contain Series metadata that is useful when generating an API, for
   example.
-- Separate JSON files for each Star Trek series though we are skipping `Prodigy`
-  and `Strange New Worlds` for now).
+- A Separate JSON file for each Star Trek series, 12 to date.
 
 A tarball is included in the [releases](releases) folder and attached to each
 GitHub release.
@@ -86,8 +85,11 @@ ones.
 
 ## Current known BUGS
 
-- Single-season Series currently won't be decoded; [issue #7][i7] is open for
-  this.
+- ~~Single-season Series currently won't be decoded; [issue #7][i7] is open for
+  this.~~
+- There is no detection of two-part episodes **written as a single entry**, so
+  the numbering is a little wrong when we parse them. I will look at fixing this
+  when the main functionality is bug-free.
 
 ## Further Enhancements planned
 

--- a/output/star_trek_series_11_prodigy_episodes.json
+++ b/output/star_trek_series_11_prodigy_episodes.json
@@ -1,0 +1,75 @@
+{
+    "seasons": {
+        "1": {
+            "total": "10",
+            "season_start": "October 28, 2021",
+            "season_end": "present",
+            "episodes": [
+                {
+                    "num_overall": "1–2",
+                    "num_in_season": "n/a",
+                    "title": "Lost and Found",
+                    "link": "",
+                    "director": "Ben Hibon",
+                    "air_date": "October 28, 2021"
+                },
+                {
+                    "num_overall": "3",
+                    "num_in_season": "n/a",
+                    "title": "Starstruck",
+                    "link": "",
+                    "director": "Alan Wan",
+                    "air_date": "November 4, 2021"
+                },
+                {
+                    "num_overall": "4",
+                    "num_in_season": "n/a",
+                    "title": "Dream Catcher",
+                    "link": "",
+                    "director": "Steve Ahn & Sung Shin",
+                    "air_date": "November 11, 2021"
+                },
+                {
+                    "num_overall": "5",
+                    "num_in_season": "n/a",
+                    "title": "Terror Firma",
+                    "link": "",
+                    "director": "Alan Wan & Olga Ulanova",
+                    "air_date": "November 18, 2021"
+                },
+                {
+                    "num_overall": "6",
+                    "num_in_season": "n/a",
+                    "title": "Kobayashi",
+                    "link": "",
+                    "director": "Alan Wan",
+                    "air_date": "January 6, 2022"
+                },
+                {
+                    "num_overall": "7",
+                    "num_in_season": "n/a",
+                    "title": "First Con-tact",
+                    "link": "",
+                    "director": "Steve Ahn & Sung Shin",
+                    "air_date": "January 13, 2022"
+                },
+                {
+                    "num_overall": "8",
+                    "num_in_season": "n/a",
+                    "title": "Time Amok",
+                    "link": "",
+                    "director": "Olga Ulanova & Sung Shin",
+                    "air_date": "January 20, 2022"
+                },
+                {
+                    "num_overall": "9–10",
+                    "num_in_season": "n/a",
+                    "title": "A Moral Star",
+                    "link": "",
+                    "director": "Ben Hibon",
+                    "air_date": "January 27, 2022"
+                }
+            ]
+        }
+    }
+}

--- a/output/star_trek_series_12_strange_new_worlds_episodes.json
+++ b/output/star_trek_series_12_strange_new_worlds_episodes.json
@@ -1,0 +1,91 @@
+{
+    "seasons": {
+        "1": {
+            "total": "6",
+            "season_start": "May 5, 2022",
+            "season_end": "present",
+            "episodes": [
+                {
+                    "num_overall": "1",
+                    "num_in_season": "n/a",
+                    "title": "Strange New Worlds",
+                    "link": "",
+                    "director": "Akiva Goldsman",
+                    "air_date": "May 5, 2022"
+                },
+                {
+                    "num_overall": "2",
+                    "num_in_season": "n/a",
+                    "title": "Children of the Comet",
+                    "link": "",
+                    "director": "Maja Vrvilo",
+                    "air_date": "May 12, 2022"
+                },
+                {
+                    "num_overall": "3",
+                    "num_in_season": "n/a",
+                    "title": "Ghosts of Illyria",
+                    "link": "",
+                    "director": "Leslie Hope",
+                    "air_date": "May 19, 2022"
+                },
+                {
+                    "num_overall": "4",
+                    "num_in_season": "n/a",
+                    "title": "Memento Mori",
+                    "link": "",
+                    "director": "Dan Liu",
+                    "air_date": "May 26, 2022"
+                },
+                {
+                    "num_overall": "5",
+                    "num_in_season": "n/a",
+                    "title": "Spock Amok",
+                    "link": "",
+                    "director": "Rachel Leiterman",
+                    "air_date": "June 2, 2022"
+                },
+                {
+                    "num_overall": "6",
+                    "num_in_season": "n/a",
+                    "title": "Lift Us Where Suffering Cannot Reach",
+                    "link": "",
+                    "director": "Andi Armaganian",
+                    "air_date": "June 9, 2022"
+                },
+                {
+                    "num_overall": "7",
+                    "num_in_season": "n/a",
+                    "title": "The Serene Squall",
+                    "link": "",
+                    "director": "Sydney Freeland",
+                    "air_date": "June 16, 2022"
+                },
+                {
+                    "num_overall": "8",
+                    "num_in_season": "n/a",
+                    "title": "TBA",
+                    "link": "",
+                    "director": "Amanda Row",
+                    "air_date": "June 23, 2022"
+                },
+                {
+                    "num_overall": "9",
+                    "num_in_season": "n/a",
+                    "title": "TBA",
+                    "link": "",
+                    "director": "TBA",
+                    "air_date": "June 30, 2022"
+                },
+                {
+                    "num_overall": "10",
+                    "num_in_season": "n/a",
+                    "title": "TBA",
+                    "link": "",
+                    "director": "Chris Fisher",
+                    "air_date": "July 7, 2022"
+                }
+            ]
+        }
+    }
+}

--- a/output/star_trek_series_7_discovery_episodes.json
+++ b/output/star_trek_series_7_discovery_episodes.json
@@ -2,8 +2,8 @@
     "seasons": {
         "1": {
             "total": "15",
-            "season_start": "9",
-            "season_end": "September 24, 2017",
+            "season_start": "September 24, 2017",
+            "season_end": "February 11, 2018",
             "episodes": [
                 {
                     "num_overall": "1",

--- a/trekpedia.py
+++ b/trekpedia.py
@@ -253,17 +253,15 @@ class Trekpedia:
             else:
                 # its a standard Series with multiple seasons.
                 for season in self.get_overview_rows(overview_table):
-                    overview_row_header = season.find("th")
-                    if overview_row_header is None:
-                        # this stops the AttributeError on Discovery season 2.
-                        continue
-                    overview_row_data = season.find_all("td")
-                    table_id = overview_row_header.a["href"][1:]
-                    table = self.get_episode_table(table_id)
-
                     try:
+                        overview_row_header = season.find("th")
+                        overview_row_data = season.find_all("td")
+                        table_id = overview_row_header.a["href"][1:]
+                        table = self.get_episode_table(table_id)
+
                         season_number = int(overview_row_header.text)
                     except AttributeError:
+                        # fixes crash on Discovery season 2
                         continue
 
                     # exit the loop if we have processed the actual number of

--- a/trekpedia.py
+++ b/trekpedia.py
@@ -251,9 +251,12 @@ class Trekpedia:
                     "episodes": episodes,
                 }
             else:
-                # its a standard Series with multiple seasons
+                # its a standard Series with multiple seasons.
                 for season in self.get_overview_rows(overview_table):
                     overview_row_header = season.find("th")
+                    if overview_row_header is None:
+                        # this stops the AttributeError on Discovery season 2.
+                        continue
                     overview_row_data = season.find_all("td")
                     table_id = overview_row_header.a["href"][1:]
                     table = self.get_episode_table(table_id)


### PR DESCRIPTION
Series that are still a single-season generally don't have an overview table, so we bypassed them initially.

This PR fixes that and has a couple of tidy-up tweaks.
It has a horrible hack with a hardcoded date to fix the END date for Discovery season 2, but with the layout of that season Summary table, it would need some severe code re-writing or a hack elsewhere. It works.

Closes #7 