### PR TITLE
Fixes d/t recent changes in Wiki formatting

### DIFF
--- a/lib/trekpedia.py
+++ b/lib/trekpedia.py
@@ -151,7 +151,25 @@ class Trekpedia:
             # this area is where we need to fix errors caused by the way they
             # are now handling double-episodes in some Series (Discovery/
             # Picard).
-            # cells = episode.find_all(["th", "td"])
+            # This is a hack to fix the issue, and will be cleaned up very soon!
+            if len(cells) == 1:
+                # we only have no_in_season
+                cells.insert(
+                    1,
+                    BeautifulSoup(f"<td>{last_episode['title']}</td>", "lxml"),
+                )
+                cells.insert(
+                    2,
+                    BeautifulSoup(
+                        f"<td>{last_episode['director']}</td>", "lxml"
+                    ),
+                )
+                cells.insert(
+                    3,
+                    BeautifulSoup(
+                        f"<td>{last_episode['air_date']}</td>", "lxml"
+                    ),
+                )
             if len(cells) == 2:
                 # we only have no_in_season and original_release_date
                 cells.insert(
@@ -165,6 +183,7 @@ class Trekpedia:
                     ),
                 )
             elif len(cells) == 4:
+                # we have everything except the title
                 cells.insert(
                     1,
                     BeautifulSoup(f"<td>{last_episode['title']}</td>", "lxml"),

--- a/lib/trekpedia.py
+++ b/lib/trekpedia.py
@@ -219,8 +219,13 @@ class Trekpedia:
                 raise TypeError()
             episode_data["link"] = f"https://en.wikipedia.org{link_url}"
         except TypeError:
-            # set the link url to an empty string...
-            episode_data["link"] = ""
+            if last_episode and episode_data["title"] == last_episode["title"]:
+                # for multi-part episodes, the link is only on the first so we
+                # need to copy it over to the second.
+                episode_data["link"] = last_episode["link"]
+            else:
+                # set the link url to an empty string...
+                episode_data["link"] = ""
 
         episode_data["director"] = self.clean_string(
             cells[headers.index("directed_by")].text, brackets=True

--- a/lib/trekpedia.py
+++ b/lib/trekpedia.py
@@ -149,8 +149,7 @@ class Trekpedia:
         cells = episode.find_all("td")
         if len(cells) != len(headers):
             # this area is where we need to fix errors caused by the way they
-            # are now handling double-episodes in some Series (Discovery/
-            # Picard).
+            # are now handling double-episodes in many Series.
             # This is a hack to fix the issue, and will be cleaned up very soon!
             if len(cells) == 1:
                 # we only have no_in_season
@@ -170,7 +169,8 @@ class Trekpedia:
                         f"<td>{last_episode['air_date']}</td>", "lxml"
                     ),
                 )
-            if len(cells) == 2:
+
+            if len(cells) in [2, 3]:
                 # we only have no_in_season and original_release_date
                 cells.insert(
                     1,
@@ -181,16 +181,6 @@ class Trekpedia:
                     BeautifulSoup(
                         f"<td>{last_episode['director']}</td>", "lxml"
                     ),
-                )
-            elif len(cells) == 3:
-                # we are missing title and stardate in this case
-                cells.insert(
-                    1,
-                    BeautifulSoup(f"<td>{last_episode['title']}</td>", "lxml"),
-                )
-                cells.insert(
-                    2,
-                    BeautifulSoup("<td></td>", "lxml"),
                 )
             elif len(cells) == 4:
                 # we have everything except the title

--- a/lib/trekpedia.py
+++ b/lib/trekpedia.py
@@ -182,6 +182,16 @@ class Trekpedia:
                         f"<td>{last_episode['director']}</td>", "lxml"
                     ),
                 )
+            elif len(cells) == 3:
+                # we are missing title and stardate in this case
+                cells.insert(
+                    1,
+                    BeautifulSoup(f"<td>{last_episode['title']}</td>", "lxml"),
+                )
+                cells.insert(
+                    2,
+                    BeautifulSoup("<td></td>", "lxml"),
+                )
             elif len(cells) == 4:
                 # we have everything except the title
                 cells.insert(

--- a/lib/trekpedia.py
+++ b/lib/trekpedia.py
@@ -74,7 +74,7 @@ class Trekpedia:
             attrs={"class": "mw-headline"},
             id=re.compile(rf"{series.replace(' ', '_')}_\("),
         )
-        logo = span.findNext("img", attrs={"class": "thumbimage"})["src"]
+        logo = span.findNext("img", attrs={"class": "mw-file-element"})["src"]
         logo_url = f"https:{logo}"
         return logo_url
 

--- a/output/star_trek_series_10_lower_decks_episodes.json
+++ b/output/star_trek_series_10_lower_decks_episodes.json
@@ -9,7 +9,7 @@
                     "num_overall": "1",
                     "num_in_season": "1",
                     "title": "Second Contact",
-                    "link": "https://en.wikipedia.org/wiki/Second_Contact",
+                    "link": "",
                     "director": "Barry J. Kelly",
                     "air_date": "August 6, 2020"
                 },

--- a/output/star_trek_series_12_strange_new_worlds_episodes.json
+++ b/output/star_trek_series_12_strange_new_worlds_episodes.json
@@ -9,7 +9,7 @@
                     "num_overall": "1",
                     "num_in_season": "1",
                     "title": "Strange New Worlds",
-                    "link": "",
+                    "link": "https://en.wikipedia.org/wiki/Strange_New_Worlds_(Star_Trek:_Strange_New_Worlds)",
                     "director": "Akiva Goldsman",
                     "air_date": "May 5, 2022"
                 },
@@ -17,7 +17,7 @@
                     "num_overall": "2",
                     "num_in_season": "2",
                     "title": "Children of the Comet",
-                    "link": "",
+                    "link": "https://en.wikipedia.org/wiki/Children_of_the_Comet",
                     "director": "Maja Vrvilo",
                     "air_date": "May 12, 2022"
                 },
@@ -84,6 +84,93 @@
                     "link": "",
                     "director": "Chris Fisher",
                     "air_date": "July 7, 2022"
+                }
+            ]
+        },
+        "2": {
+            "total": "10",
+            "season_start": "June 15, 2023",
+            "season_end": "August 10, 2023",
+            "episodes": [
+                {
+                    "num_overall": "11",
+                    "num_in_season": "1",
+                    "title": "The Broken Circle",
+                    "link": "",
+                    "director": "Chris Fisher",
+                    "air_date": "June 15, 2023"
+                },
+                {
+                    "num_overall": "12",
+                    "num_in_season": "2",
+                    "title": "Ad Astra per Aspera",
+                    "link": "",
+                    "director": "Valerie Weiss",
+                    "air_date": "June 22, 2023"
+                },
+                {
+                    "num_overall": "13",
+                    "num_in_season": "3",
+                    "title": "Tomorrow and Tomorrow and Tomorrow",
+                    "link": "",
+                    "director": "Amanda Row",
+                    "air_date": "June 29, 2023"
+                },
+                {
+                    "num_overall": "14",
+                    "num_in_season": "4",
+                    "title": "Among the Lotus Eaters",
+                    "link": "",
+                    "director": "Eduardo Sánchez",
+                    "air_date": "July 6, 2023"
+                },
+                {
+                    "num_overall": "15",
+                    "num_in_season": "5",
+                    "title": "Charades",
+                    "link": "",
+                    "director": "Jordan Canning",
+                    "air_date": "July 13, 2023"
+                },
+                {
+                    "num_overall": "16",
+                    "num_in_season": "6",
+                    "title": "Lost in Translation",
+                    "link": "",
+                    "director": "Dan Liu",
+                    "air_date": "July 20, 2023"
+                },
+                {
+                    "num_overall": "17",
+                    "num_in_season": "7",
+                    "title": "Those Old Scientists",
+                    "link": "",
+                    "director": "Jonathan Frakes",
+                    "air_date": "July 22, 2023"
+                },
+                {
+                    "num_overall": "18",
+                    "num_in_season": "8",
+                    "title": "Under the Cloak of War",
+                    "link": "",
+                    "director": "Jeff W. Byrd",
+                    "air_date": "July 27, 2023"
+                },
+                {
+                    "num_overall": "19",
+                    "num_in_season": "9",
+                    "title": "Subspace Rhapsody",
+                    "link": "",
+                    "director": "Dermott Downs",
+                    "air_date": "August 3, 2023"
+                },
+                {
+                    "num_overall": "20",
+                    "num_in_season": "10",
+                    "title": "Hegemony",
+                    "link": "",
+                    "director": "Maja Vrvilo",
+                    "air_date": "August 10, 2023"
                 }
             ]
         }

--- a/output/star_trek_series_3_the_next_generation_episodes.json
+++ b/output/star_trek_series_3_the_next_generation_episodes.json
@@ -11,7 +11,7 @@
                     "title": "Encounter at Farpoint",
                     "link": "https://en.wikipedia.org/wiki/Encounter_at_Farpoint",
                     "director": "Corey Allen",
-                    "air_date": "September 28, 1987"
+                    "air_date": "September 26, 1987"
                 },
                 {
                     "num_overall": "3",
@@ -19,7 +19,7 @@
                     "title": "The Naked Now",
                     "link": "https://en.wikipedia.org/wiki/The_Naked_Now",
                     "director": "Paul Lynch",
-                    "air_date": "October 5, 1987"
+                    "air_date": "October 3, 1987"
                 },
                 {
                     "num_overall": "4",
@@ -27,7 +27,7 @@
                     "title": "Code of Honor",
                     "link": "https://en.wikipedia.org/wiki/Code_of_Honor_(Star_Trek:_The_Next_Generation)",
                     "director": "Russ Mayberry",
-                    "air_date": "October 12, 1987"
+                    "air_date": "October 10, 1987"
                 },
                 {
                     "num_overall": "5",
@@ -35,7 +35,7 @@
                     "title": "The Last Outpost",
                     "link": "https://en.wikipedia.org/wiki/The_Last_Outpost_(Star_Trek:_The_Next_Generation)",
                     "director": "Richard Colla",
-                    "air_date": "October 19, 1987"
+                    "air_date": "October 17, 1987"
                 },
                 {
                     "num_overall": "6",
@@ -43,7 +43,7 @@
                     "title": "Where No One Has Gone Before",
                     "link": "https://en.wikipedia.org/wiki/Where_No_One_Has_Gone_Before",
                     "director": "Rob Bowman",
-                    "air_date": "October 26, 1987"
+                    "air_date": "October 24, 1987"
                 },
                 {
                     "num_overall": "7",
@@ -51,7 +51,7 @@
                     "title": "Lonely Among Us",
                     "link": "https://en.wikipedia.org/wiki/Lonely_Among_Us",
                     "director": "Cliff Bole",
-                    "air_date": "November 2, 1987"
+                    "air_date": "October 31, 1987"
                 },
                 {
                     "num_overall": "8",
@@ -59,7 +59,7 @@
                     "title": "Justice",
                     "link": "https://en.wikipedia.org/wiki/Justice_(Star_Trek:_The_Next_Generation)",
                     "director": "James L. Conway",
-                    "air_date": "November 9, 1987"
+                    "air_date": "November 7, 1987"
                 },
                 {
                     "num_overall": "9",
@@ -67,7 +67,7 @@
                     "title": "The Battle",
                     "link": "https://en.wikipedia.org/wiki/The_Battle_(Star_Trek:_The_Next_Generation)",
                     "director": "Rob Bowman",
-                    "air_date": "November 16, 1987"
+                    "air_date": "November 14, 1987"
                 },
                 {
                     "num_overall": "10",
@@ -75,7 +75,7 @@
                     "title": "Hide and Q",
                     "link": "https://en.wikipedia.org/wiki/Hide_and_Q",
                     "director": "Cliff Bole",
-                    "air_date": "November 23, 1987"
+                    "air_date": "November 21, 1987"
                 },
                 {
                     "num_overall": "11",
@@ -83,7 +83,7 @@
                     "title": "Haven",
                     "link": "https://en.wikipedia.org/wiki/Haven_(Star_Trek:_The_Next_Generation)",
                     "director": "Richard Compton",
-                    "air_date": "November 30, 1987"
+                    "air_date": "November 28, 1987"
                 },
                 {
                     "num_overall": "12",
@@ -91,7 +91,7 @@
                     "title": "The Big Goodbye",
                     "link": "https://en.wikipedia.org/wiki/The_Big_Goodbye",
                     "director": "Joseph L. Scanlan",
-                    "air_date": "January 11, 1988"
+                    "air_date": "January 9, 1988"
                 },
                 {
                     "num_overall": "13",
@@ -99,7 +99,7 @@
                     "title": "Datalore",
                     "link": "https://en.wikipedia.org/wiki/Datalore",
                     "director": "Rob Bowman",
-                    "air_date": "January 18, 1988"
+                    "air_date": "January 16, 1988"
                 },
                 {
                     "num_overall": "14",
@@ -107,7 +107,7 @@
                     "title": "Angel One",
                     "link": "https://en.wikipedia.org/wiki/Angel_One",
                     "director": "Michael Rhodes",
-                    "air_date": "January 25, 1988"
+                    "air_date": "January 23, 1988"
                 },
                 {
                     "num_overall": "15",
@@ -115,7 +115,7 @@
                     "title": "11001001",
                     "link": "https://en.wikipedia.org/wiki/11001001",
                     "director": "Paul Lynch",
-                    "air_date": "February 1, 1988"
+                    "air_date": "January 30, 1988"
                 },
                 {
                     "num_overall": "16",
@@ -123,7 +123,7 @@
                     "title": "Too Short a Season",
                     "link": "https://en.wikipedia.org/wiki/Too_Short_a_Season",
                     "director": "Rob Bowman",
-                    "air_date": "February 8, 1988"
+                    "air_date": "February 7, 1988"
                 },
                 {
                     "num_overall": "17",
@@ -131,7 +131,7 @@
                     "title": "When the Bough Breaks",
                     "link": "https://en.wikipedia.org/wiki/When_the_Bough_Breaks_(Star_Trek:_The_Next_Generation)",
                     "director": "Kim Manners",
-                    "air_date": "February 15, 1988"
+                    "air_date": "February 14, 1988"
                 },
                 {
                     "num_overall": "18",
@@ -139,7 +139,7 @@
                     "title": "Home Soil",
                     "link": "https://en.wikipedia.org/wiki/Home_Soil",
                     "director": "Corey Allen",
-                    "air_date": "February 22, 1988"
+                    "air_date": "February 21, 1988"
                 },
                 {
                     "num_overall": "19",
@@ -147,7 +147,7 @@
                     "title": "Coming of Age",
                     "link": "https://en.wikipedia.org/wiki/Coming_of_Age_(Star_Trek:_The_Next_Generation)",
                     "director": "Mike Vejar",
-                    "air_date": "March 14, 1988"
+                    "air_date": "March 12, 1988"
                 },
                 {
                     "num_overall": "20",
@@ -155,7 +155,7 @@
                     "title": "Heart of Glory",
                     "link": "https://en.wikipedia.org/wiki/Heart_of_Glory",
                     "director": "Rob Bowman",
-                    "air_date": "March 21, 1988"
+                    "air_date": "March 19, 1988"
                 },
                 {
                     "num_overall": "21",
@@ -163,7 +163,7 @@
                     "title": "The Arsenal of Freedom",
                     "link": "https://en.wikipedia.org/wiki/The_Arsenal_of_Freedom",
                     "director": "Les Landau",
-                    "air_date": "April 11, 1988"
+                    "air_date": "April 9, 1988"
                 },
                 {
                     "num_overall": "22",
@@ -171,7 +171,7 @@
                     "title": "Symbiosis",
                     "link": "https://en.wikipedia.org/wiki/Symbiosis_(Star_Trek:_The_Next_Generation)",
                     "director": "Win Phelps",
-                    "air_date": "April 18, 1988"
+                    "air_date": "April 16, 1988"
                 },
                 {
                     "num_overall": "23",
@@ -179,7 +179,7 @@
                     "title": "Skin of Evil",
                     "link": "https://en.wikipedia.org/wiki/Skin_of_Evil",
                     "director": "Joseph L. Scanlan",
-                    "air_date": "April 25, 1988"
+                    "air_date": "April 23, 1988"
                 },
                 {
                     "num_overall": "24",
@@ -187,7 +187,7 @@
                     "title": "We'll Always Have Paris",
                     "link": "https://en.wikipedia.org/wiki/We%27ll_Always_Have_Paris_(Star_Trek:_The_Next_Generation)",
                     "director": "Robert Becker",
-                    "air_date": "May 2, 1988"
+                    "air_date": "April 30, 1988"
                 },
                 {
                     "num_overall": "25",
@@ -195,7 +195,7 @@
                     "title": "Conspiracy",
                     "link": "https://en.wikipedia.org/wiki/Conspiracy_(Star_Trek:_The_Next_Generation)",
                     "director": "Cliff Bole",
-                    "air_date": "May 9, 1988"
+                    "air_date": "May 7, 1988"
                 },
                 {
                     "num_overall": "26",
@@ -203,7 +203,7 @@
                     "title": "The Neutral Zone",
                     "link": "https://en.wikipedia.org/wiki/The_Neutral_Zone_(Star_Trek:_The_Next_Generation)",
                     "director": "James L. Conway",
-                    "air_date": "May 16, 1988"
+                    "air_date": "May 14, 1988"
                 }
             ]
         },
@@ -396,20 +396,20 @@
             "season_end": "June 18, 1990",
             "episodes": [
                 {
-                    "num_overall": "50",
+                    "num_overall": "49",
                     "num_in_season": "1",
                     "title": "Evolution",
                     "link": "https://en.wikipedia.org/wiki/Evolution_(Star_Trek:_The_Next_Generation)",
                     "director": "Winrich Kolbe",
-                    "air_date": "September 25, 1989"
+                    "air_date": "September 23, 1989"
                 },
                 {
-                    "num_overall": "49",
+                    "num_overall": "50",
                     "num_in_season": "2",
                     "title": "The Ensigns of Command",
                     "link": "https://en.wikipedia.org/wiki/The_Ensigns_of_Command",
                     "director": "Cliff Bole",
-                    "air_date": "October 2, 1989"
+                    "air_date": "September 30, 1989"
                 },
                 {
                     "num_overall": "51",
@@ -417,7 +417,7 @@
                     "title": "The Survivors",
                     "link": "https://en.wikipedia.org/wiki/The_Survivors_(Star_Trek:_The_Next_Generation)",
                     "director": "Les Landau",
-                    "air_date": "October 9, 1989"
+                    "air_date": "October 7, 1989"
                 },
                 {
                     "num_overall": "52",
@@ -425,7 +425,7 @@
                     "title": "Who Watches the Watchers",
                     "link": "https://en.wikipedia.org/wiki/Who_Watches_the_Watchers",
                     "director": "Robert Wiemer",
-                    "air_date": "October 16, 1989"
+                    "air_date": "October 14, 1989"
                 },
                 {
                     "num_overall": "53",
@@ -433,7 +433,7 @@
                     "title": "The Bonding",
                     "link": "https://en.wikipedia.org/wiki/The_Bonding",
                     "director": "Winrich Kolbe",
-                    "air_date": "October 23, 1989"
+                    "air_date": "October 21, 1989"
                 },
                 {
                     "num_overall": "54",
@@ -441,7 +441,7 @@
                     "title": "Booby Trap",
                     "link": "https://en.wikipedia.org/wiki/Booby_Trap_(Star_Trek:_The_Next_Generation)",
                     "director": "Gabrielle Beaumont",
-                    "air_date": "October 30, 1989"
+                    "air_date": "October 28, 1989"
                 },
                 {
                     "num_overall": "55",
@@ -449,7 +449,7 @@
                     "title": "The Enemy",
                     "link": "https://en.wikipedia.org/wiki/The_Enemy_(Star_Trek:_The_Next_Generation)",
                     "director": "David Carson",
-                    "air_date": "November 6, 1989"
+                    "air_date": "November 4, 1989"
                 },
                 {
                     "num_overall": "56",
@@ -457,7 +457,7 @@
                     "title": "The Price",
                     "link": "https://en.wikipedia.org/wiki/The_Price_(Star_Trek:_The_Next_Generation)",
                     "director": "Robert Scheerer",
-                    "air_date": "November 13, 1989"
+                    "air_date": "November 11, 1989"
                 },
                 {
                     "num_overall": "57",
@@ -465,7 +465,7 @@
                     "title": "The Vengeance Factor",
                     "link": "https://en.wikipedia.org/wiki/The_Vengeance_Factor",
                     "director": "Timothy Bond",
-                    "air_date": "November 20, 1989"
+                    "air_date": "November 18, 1989"
                 },
                 {
                     "num_overall": "58",
@@ -473,7 +473,7 @@
                     "title": "The Defector",
                     "link": "https://en.wikipedia.org/wiki/The_Defector_(Star_Trek:_The_Next_Generation)",
                     "director": "Robert Scheerer",
-                    "air_date": "January 1, 1990"
+                    "air_date": "December 30, 1989"
                 },
                 {
                     "num_overall": "59",
@@ -481,7 +481,7 @@
                     "title": "The Hunted",
                     "link": "https://en.wikipedia.org/wiki/The_Hunted_(Star_Trek:_The_Next_Generation)",
                     "director": "Cliff Bole",
-                    "air_date": "January 8, 1990"
+                    "air_date": "January 6, 1990"
                 },
                 {
                     "num_overall": "60",
@@ -489,7 +489,7 @@
                     "title": "The High Ground",
                     "link": "https://en.wikipedia.org/wiki/The_High_Ground_(Star_Trek:_The_Next_Generation)",
                     "director": "Gabrielle Beaumont",
-                    "air_date": "January 29, 1990"
+                    "air_date": "January 27, 1990"
                 },
                 {
                     "num_overall": "61",
@@ -497,7 +497,7 @@
                     "title": "Deja Q",
                     "link": "https://en.wikipedia.org/wiki/Deja_Q",
                     "director": "Les Landau",
-                    "air_date": "February 5, 1990"
+                    "air_date": "February 3, 1990"
                 },
                 {
                     "num_overall": "62",
@@ -505,7 +505,7 @@
                     "title": "A Matter of Perspective",
                     "link": "https://en.wikipedia.org/wiki/A_Matter_of_Perspective",
                     "director": "Cliff Bole",
-                    "air_date": "February 12, 1990"
+                    "air_date": "February 10, 1990"
                 },
                 {
                     "num_overall": "63",
@@ -513,7 +513,7 @@
                     "title": "Yesterday's Enterprise",
                     "link": "https://en.wikipedia.org/wiki/Yesterday%27s_Enterprise",
                     "director": "David Carson",
-                    "air_date": "February 19, 1990"
+                    "air_date": "February 17, 1990"
                 },
                 {
                     "num_overall": "64",
@@ -521,7 +521,7 @@
                     "title": "The Offspring",
                     "link": "https://en.wikipedia.org/wiki/The_Offspring_(Star_Trek:_The_Next_Generation)",
                     "director": "Jonathan Frakes",
-                    "air_date": "March 12, 1990"
+                    "air_date": "March 10, 1990"
                 },
                 {
                     "num_overall": "65",
@@ -529,7 +529,7 @@
                     "title": "Sins of the Father",
                     "link": "https://en.wikipedia.org/wiki/Sins_of_the_Father_(Star_Trek:_The_Next_Generation)",
                     "director": "Les Landau",
-                    "air_date": "March 19, 1990"
+                    "air_date": "March 17, 1990"
                 },
                 {
                     "num_overall": "66",
@@ -537,7 +537,7 @@
                     "title": "Allegiance",
                     "link": "https://en.wikipedia.org/wiki/Allegiance_(Star_Trek:_The_Next_Generation)",
                     "director": "Winrich Kolbe",
-                    "air_date": "March 26, 1990"
+                    "air_date": "March 24, 1990"
                 },
                 {
                     "num_overall": "67",
@@ -545,7 +545,7 @@
                     "title": "Captain's Holiday",
                     "link": "https://en.wikipedia.org/wiki/Captain%27s_Holiday",
                     "director": "Chip Chalmers",
-                    "air_date": "April 2, 1990"
+                    "air_date": "March 31, 1990"
                 },
                 {
                     "num_overall": "68",
@@ -553,7 +553,7 @@
                     "title": "Tin Man",
                     "link": "https://en.wikipedia.org/wiki/Tin_Man_(Star_Trek:_The_Next_Generation)",
                     "director": "Robert Scheerer",
-                    "air_date": "April 23, 1990"
+                    "air_date": "April 21, 1990"
                 },
                 {
                     "num_overall": "69",
@@ -561,7 +561,7 @@
                     "title": "Hollow Pursuits",
                     "link": "https://en.wikipedia.org/wiki/Hollow_Pursuits",
                     "director": "Cliff Bole",
-                    "air_date": "April 30, 1990"
+                    "air_date": "April 28, 1990"
                 },
                 {
                     "num_overall": "70",
@@ -569,7 +569,7 @@
                     "title": "The Most Toys",
                     "link": "https://en.wikipedia.org/wiki/The_Most_Toys",
                     "director": "Timothy Bond",
-                    "air_date": "May 7, 1990"
+                    "air_date": "May 5, 1990"
                 },
                 {
                     "num_overall": "71",
@@ -577,7 +577,7 @@
                     "title": "Sarek",
                     "link": "https://en.wikipedia.org/wiki/Sarek_(Star_Trek:_The_Next_Generation)",
                     "director": "Les Landau",
-                    "air_date": "May 14, 1990"
+                    "air_date": "May 12, 1990"
                 },
                 {
                     "num_overall": "72",
@@ -585,7 +585,7 @@
                     "title": "Ménage à Troi",
                     "link": "https://en.wikipedia.org/wiki/M%C3%A9nage_%C3%A0_Troi",
                     "director": "Robert Legato",
-                    "air_date": "May 28, 1990"
+                    "air_date": "May 26, 1990"
                 },
                 {
                     "num_overall": "73",
@@ -593,7 +593,7 @@
                     "title": "Transfigurations",
                     "link": "https://en.wikipedia.org/wiki/Transfigurations",
                     "director": "Tom Benko",
-                    "air_date": "June 4, 1990"
+                    "air_date": "June 2, 1990"
                 },
                 {
                     "num_overall": "74",
@@ -601,7 +601,7 @@
                     "title": "The Best of Both Worlds, Part I",
                     "link": "https://en.wikipedia.org/wiki/The_Best_of_Both_Worlds_(Star_Trek:_The_Next_Generation)",
                     "director": "Cliff Bole",
-                    "air_date": "June 18, 1990"
+                    "air_date": "June 16, 1990"
                 }
             ]
         },
@@ -616,7 +616,7 @@
                     "title": "The Best of Both Worlds, Part II",
                     "link": "https://en.wikipedia.org/wiki/The_Best_of_Both_Worlds_(Star_Trek:_The_Next_Generation)",
                     "director": "Cliff Bole",
-                    "air_date": "September 24, 1990"
+                    "air_date": "September 22, 1990"
                 },
                 {
                     "num_overall": "76",
@@ -624,7 +624,7 @@
                     "title": "Family",
                     "link": "https://en.wikipedia.org/wiki/Family_(Star_Trek:_The_Next_Generation)",
                     "director": "Les Landau",
-                    "air_date": "October 1, 1990"
+                    "air_date": "September 29, 1990"
                 },
                 {
                     "num_overall": "77",
@@ -632,7 +632,7 @@
                     "title": "Brothers",
                     "link": "https://en.wikipedia.org/wiki/Brothers_(Star_Trek:_The_Next_Generation)",
                     "director": "Rob Bowman",
-                    "air_date": "October 8, 1990"
+                    "air_date": "October 6, 1990"
                 },
                 {
                     "num_overall": "78",
@@ -640,7 +640,7 @@
                     "title": "Suddenly Human",
                     "link": "https://en.wikipedia.org/wiki/Suddenly_Human",
                     "director": "Gabrielle Beaumont",
-                    "air_date": "October 15, 1990"
+                    "air_date": "October 13, 1990"
                 },
                 {
                     "num_overall": "79",
@@ -648,7 +648,7 @@
                     "title": "Remember Me",
                     "link": "https://en.wikipedia.org/wiki/Remember_Me_(Star_Trek:_The_Next_Generation)",
                     "director": "Cliff Bole",
-                    "air_date": "October 22, 1990"
+                    "air_date": "October 20, 1990"
                 },
                 {
                     "num_overall": "80",
@@ -656,7 +656,7 @@
                     "title": "Legacy",
                     "link": "https://en.wikipedia.org/wiki/Legacy_(Star_Trek:_The_Next_Generation)",
                     "director": "Robert Scheerer",
-                    "air_date": "October 29, 1990"
+                    "air_date": "October 27, 1990"
                 },
                 {
                     "num_overall": "81",
@@ -664,7 +664,7 @@
                     "title": "Reunion",
                     "link": "https://en.wikipedia.org/wiki/Reunion_(Star_Trek:_The_Next_Generation)",
                     "director": "Jonathan Frakes",
-                    "air_date": "November 5, 1990"
+                    "air_date": "November 3, 1990"
                 },
                 {
                     "num_overall": "82",
@@ -672,7 +672,7 @@
                     "title": "Future Imperfect",
                     "link": "https://en.wikipedia.org/wiki/Future_Imperfect",
                     "director": "Les Landau",
-                    "air_date": "November 12, 1990"
+                    "air_date": "November 10, 1990"
                 },
                 {
                     "num_overall": "83",
@@ -680,7 +680,7 @@
                     "title": "Final Mission",
                     "link": "https://en.wikipedia.org/wiki/Final_Mission",
                     "director": "Corey Allen",
-                    "air_date": "November 19, 1990"
+                    "air_date": "November 17, 1990"
                 },
                 {
                     "num_overall": "84",
@@ -688,7 +688,7 @@
                     "title": "The Loss",
                     "link": "https://en.wikipedia.org/wiki/The_Loss",
                     "director": "Chip Chalmers",
-                    "air_date": "December 31, 1990"
+                    "air_date": "December 29, 1990"
                 },
                 {
                     "num_overall": "85",
@@ -696,7 +696,7 @@
                     "title": "Data's Day",
                     "link": "https://en.wikipedia.org/wiki/Data%27s_Day",
                     "director": "Robert Wiemer",
-                    "air_date": "January 7, 1991"
+                    "air_date": "January 5, 1991"
                 },
                 {
                     "num_overall": "86",
@@ -704,7 +704,7 @@
                     "title": "The Wounded",
                     "link": "https://en.wikipedia.org/wiki/The_Wounded_(Star_Trek:_The_Next_Generation)",
                     "director": "Chip Chalmers",
-                    "air_date": "January 28, 1991"
+                    "air_date": "January 26, 1991"
                 },
                 {
                     "num_overall": "87",
@@ -712,7 +712,7 @@
                     "title": "Devil's Due",
                     "link": "https://en.wikipedia.org/wiki/Devil%27s_Due_(Star_Trek:_The_Next_Generation)",
                     "director": "Tom Benko",
-                    "air_date": "February 4, 1991"
+                    "air_date": "February 2, 1991"
                 },
                 {
                     "num_overall": "88",
@@ -720,7 +720,7 @@
                     "title": "Clues",
                     "link": "https://en.wikipedia.org/wiki/Clues_(Star_Trek:_The_Next_Generation)",
                     "director": "Les Landau",
-                    "air_date": "February 11, 1991"
+                    "air_date": "February 9, 1991"
                 },
                 {
                     "num_overall": "89",
@@ -728,7 +728,7 @@
                     "title": "First Contact",
                     "link": "https://en.wikipedia.org/wiki/First_Contact_(Star_Trek:_The_Next_Generation)",
                     "director": "Cliff Bole",
-                    "air_date": "February 18, 1991"
+                    "air_date": "February 16, 1991"
                 },
                 {
                     "num_overall": "90",
@@ -736,7 +736,7 @@
                     "title": "Galaxy's Child",
                     "link": "https://en.wikipedia.org/wiki/Galaxy%27s_Child",
                     "director": "Winrich Kolbe",
-                    "air_date": "March 11, 1991"
+                    "air_date": "March 9, 1991"
                 },
                 {
                     "num_overall": "91",
@@ -744,7 +744,7 @@
                     "title": "Night Terrors",
                     "link": "https://en.wikipedia.org/wiki/Night_Terrors_(Star_Trek:_The_Next_Generation)",
                     "director": "Les Landau",
-                    "air_date": "March 18, 1991"
+                    "air_date": "March 16, 1991"
                 },
                 {
                     "num_overall": "92",
@@ -752,7 +752,7 @@
                     "title": "Identity Crisis",
                     "link": "https://en.wikipedia.org/wiki/Identity_Crisis_(Star_Trek:_The_Next_Generation)",
                     "director": "Winrich Kolbe",
-                    "air_date": "March 25, 1991"
+                    "air_date": "March 23, 1991"
                 },
                 {
                     "num_overall": "93",
@@ -760,7 +760,7 @@
                     "title": "The Nth Degree",
                     "link": "https://en.wikipedia.org/wiki/The_Nth_Degree_(Star_Trek:_The_Next_Generation)",
                     "director": "Robert Legato",
-                    "air_date": "April 1, 1991"
+                    "air_date": "March 30, 1991"
                 },
                 {
                     "num_overall": "94",
@@ -768,7 +768,7 @@
                     "title": "Qpid",
                     "link": "https://en.wikipedia.org/wiki/Qpid",
                     "director": "Cliff Bole",
-                    "air_date": "April 22, 1991"
+                    "air_date": "April 20, 1991"
                 },
                 {
                     "num_overall": "95",
@@ -776,7 +776,7 @@
                     "title": "The Drumhead",
                     "link": "https://en.wikipedia.org/wiki/The_Drumhead",
                     "director": "Jonathan Frakes",
-                    "air_date": "April 29, 1991"
+                    "air_date": "April 27, 1991"
                 },
                 {
                     "num_overall": "96",
@@ -784,7 +784,7 @@
                     "title": "Half a Life",
                     "link": "https://en.wikipedia.org/wiki/Half_a_Life_(Star_Trek:_The_Next_Generation)",
                     "director": "Les Landau",
-                    "air_date": "May 6, 1991"
+                    "air_date": "May 4, 1991"
                 },
                 {
                     "num_overall": "97",
@@ -792,7 +792,7 @@
                     "title": "The Host",
                     "link": "https://en.wikipedia.org/wiki/The_Host_(Star_Trek:_The_Next_Generation)",
                     "director": "Marvin V. Rush",
-                    "air_date": "May 13, 1991"
+                    "air_date": "May 11, 1991"
                 },
                 {
                     "num_overall": "98",
@@ -800,7 +800,7 @@
                     "title": "The Mind's Eye",
                     "link": "https://en.wikipedia.org/wiki/The_Mind%27s_Eye_(Star_Trek:_The_Next_Generation)",
                     "director": "David Livingston",
-                    "air_date": "May 27, 1991"
+                    "air_date": "May 25, 1991"
                 },
                 {
                     "num_overall": "99",
@@ -808,7 +808,7 @@
                     "title": "In Theory",
                     "link": "https://en.wikipedia.org/wiki/In_Theory_(Star_Trek:_The_Next_Generation)",
                     "director": "Patrick Stewart",
-                    "air_date": "June 3, 1991"
+                    "air_date": "June 1, 1991"
                 },
                 {
                     "num_overall": "100",
@@ -816,7 +816,7 @@
                     "title": "Redemption, Part I",
                     "link": "https://en.wikipedia.org/wiki/Redemption_(Star_Trek:_The_Next_Generation)",
                     "director": "Cliff Bole",
-                    "air_date": "June 17, 1991"
+                    "air_date": "June 15, 1991"
                 }
             ]
         },
@@ -1046,7 +1046,7 @@
                     "title": "Time's Arrow, Part II",
                     "link": "https://en.wikipedia.org/wiki/Time%27s_Arrow_(Star_Trek:_The_Next_Generation)",
                     "director": "Les Landau",
-                    "air_date": "September 21, 1992"
+                    "air_date": "September 19, 1992"
                 },
                 {
                     "num_overall": "128",
@@ -1054,7 +1054,7 @@
                     "title": "Realm of Fear",
                     "link": "https://en.wikipedia.org/wiki/Realm_of_Fear",
                     "director": "Cliff Bole",
-                    "air_date": "September 28, 1992"
+                    "air_date": "September 26, 1992"
                 },
                 {
                     "num_overall": "129",
@@ -1062,7 +1062,7 @@
                     "title": "Man of the People",
                     "link": "https://en.wikipedia.org/wiki/Man_of_the_People_(Star_Trek:_The_Next_Generation)",
                     "director": "Winrich Kolbe",
-                    "air_date": "October 5, 1992"
+                    "air_date": "October 3, 1992"
                 },
                 {
                     "num_overall": "130",
@@ -1070,7 +1070,7 @@
                     "title": "Relics",
                     "link": "https://en.wikipedia.org/wiki/Relics_(Star_Trek:_The_Next_Generation)",
                     "director": "Alexander Singer",
-                    "air_date": "October 12, 1992"
+                    "air_date": "October 10, 1992"
                 },
                 {
                     "num_overall": "131",
@@ -1078,7 +1078,7 @@
                     "title": "Schisms",
                     "link": "https://en.wikipedia.org/wiki/Schisms_(Star_Trek:_The_Next_Generation)",
                     "director": "Robert Wiemer",
-                    "air_date": "October 19, 1992"
+                    "air_date": "October 17, 1992"
                 },
                 {
                     "num_overall": "132",
@@ -1086,7 +1086,7 @@
                     "title": "True Q",
                     "link": "https://en.wikipedia.org/wiki/True_Q",
                     "director": "Robert Scheerer",
-                    "air_date": "October 26, 1992"
+                    "air_date": "October 24, 1992"
                 },
                 {
                     "num_overall": "133",
@@ -1094,7 +1094,7 @@
                     "title": "Rascals",
                     "link": "https://en.wikipedia.org/wiki/Rascals_(Star_Trek:_The_Next_Generation)",
                     "director": "Adam Nimoy",
-                    "air_date": "November 2, 1992"
+                    "air_date": "October 31, 1992"
                 },
                 {
                     "num_overall": "134",
@@ -1102,7 +1102,7 @@
                     "title": "A Fistful of Datas",
                     "link": "https://en.wikipedia.org/wiki/A_Fistful_of_Datas",
                     "director": "Patrick Stewart",
-                    "air_date": "November 9, 1992"
+                    "air_date": "November 7, 1992"
                 },
                 {
                     "num_overall": "135",
@@ -1110,7 +1110,7 @@
                     "title": "The Quality of Life",
                     "link": "https://en.wikipedia.org/wiki/The_Quality_of_Life_(Star_Trek:_The_Next_Generation)",
                     "director": "Jonathan Frakes",
-                    "air_date": "November 16, 1992"
+                    "air_date": "November 14, 1992"
                 },
                 {
                     "num_overall": "136",
@@ -1118,7 +1118,7 @@
                     "title": "Chain of Command, Part I",
                     "link": "https://en.wikipedia.org/wiki/Chain_of_Command_(Star_Trek:_The_Next_Generation)",
                     "director": "Robert Scheerer",
-                    "air_date": "December 14, 1992"
+                    "air_date": "December 12, 1992"
                 },
                 {
                     "num_overall": "137",
@@ -1126,7 +1126,7 @@
                     "title": "Chain of Command, Part II",
                     "link": "https://en.wikipedia.org/wiki/Chain_of_Command_(Star_Trek:_The_Next_Generation)",
                     "director": "Les Landau",
-                    "air_date": "December 21, 1992"
+                    "air_date": "December 19, 1992"
                 },
                 {
                     "num_overall": "138",
@@ -1134,7 +1134,7 @@
                     "title": "Ship in a Bottle",
                     "link": "https://en.wikipedia.org/wiki/Ship_in_a_Bottle_(Star_Trek:_The_Next_Generation)",
                     "director": "Alexander Singer",
-                    "air_date": "January 25, 1993"
+                    "air_date": "January 23, 1993"
                 },
                 {
                     "num_overall": "139",
@@ -1142,7 +1142,7 @@
                     "title": "Aquiel",
                     "link": "https://en.wikipedia.org/wiki/Aquiel",
                     "director": "Cliff Bole",
-                    "air_date": "February 1, 1993"
+                    "air_date": "January 30, 1993"
                 },
                 {
                     "num_overall": "140",
@@ -1150,7 +1150,7 @@
                     "title": "Face of the Enemy",
                     "link": "https://en.wikipedia.org/wiki/Face_of_the_Enemy_(Star_Trek:_The_Next_Generation)",
                     "director": "Gabrielle Beaumont",
-                    "air_date": "February 8, 1993"
+                    "air_date": "February 6, 1993"
                 },
                 {
                     "num_overall": "141",
@@ -1158,7 +1158,7 @@
                     "title": "Tapestry",
                     "link": "https://en.wikipedia.org/wiki/Tapestry_(Star_Trek:_The_Next_Generation)",
                     "director": "Les Landau",
-                    "air_date": "February 15, 1993"
+                    "air_date": "February 13, 1993"
                 },
                 {
                     "num_overall": "142",
@@ -1166,7 +1166,7 @@
                     "title": "Birthright, Part I",
                     "link": "https://en.wikipedia.org/wiki/Birthright_(Star_Trek:_The_Next_Generation)",
                     "director": "Winrich Kolbe",
-                    "air_date": "February 22, 1993"
+                    "air_date": "February 20, 1993"
                 },
                 {
                     "num_overall": "143",
@@ -1174,7 +1174,7 @@
                     "title": "Birthright, Part II",
                     "link": "https://en.wikipedia.org/wiki/Birthright_(Star_Trek:_The_Next_Generation)",
                     "director": "Dan Curry",
-                    "air_date": "March 1, 1993"
+                    "air_date": "February 27, 1993"
                 },
                 {
                     "num_overall": "144",
@@ -1182,7 +1182,7 @@
                     "title": "Starship Mine",
                     "link": "https://en.wikipedia.org/wiki/Starship_Mine",
                     "director": "Cliff Bole",
-                    "air_date": "March 29, 1993"
+                    "air_date": "March 27, 1993"
                 },
                 {
                     "num_overall": "145",
@@ -1190,7 +1190,7 @@
                     "title": "Lessons",
                     "link": "https://en.wikipedia.org/wiki/Lessons_(Star_Trek:_The_Next_Generation)",
                     "director": "Robert Wiemer",
-                    "air_date": "April 5, 1993"
+                    "air_date": "April 3, 1993"
                 },
                 {
                     "num_overall": "146",
@@ -1198,7 +1198,7 @@
                     "title": "The Chase",
                     "link": "https://en.wikipedia.org/wiki/The_Chase_(Star_Trek:_The_Next_Generation)",
                     "director": "Jonathan Frakes",
-                    "air_date": "April 26, 1993"
+                    "air_date": "April 24, 1993"
                 },
                 {
                     "num_overall": "147",
@@ -1206,7 +1206,7 @@
                     "title": "Frame of Mind",
                     "link": "https://en.wikipedia.org/wiki/Frame_of_Mind_(Star_Trek:_The_Next_Generation)",
                     "director": "James L. Conway",
-                    "air_date": "May 3, 1993"
+                    "air_date": "May 1, 1993"
                 },
                 {
                     "num_overall": "148",
@@ -1214,7 +1214,7 @@
                     "title": "Suspicions",
                     "link": "https://en.wikipedia.org/wiki/Suspicions_(Star_Trek:_The_Next_Generation)",
                     "director": "Cliff Bole",
-                    "air_date": "May 10, 1993"
+                    "air_date": "May 8, 1993"
                 },
                 {
                     "num_overall": "149",
@@ -1222,7 +1222,7 @@
                     "title": "Rightful Heir",
                     "link": "https://en.wikipedia.org/wiki/Rightful_Heir",
                     "director": "Winrich Kolbe",
-                    "air_date": "May 17, 1993"
+                    "air_date": "May 15, 1993"
                 },
                 {
                     "num_overall": "150",
@@ -1230,7 +1230,7 @@
                     "title": "Second Chances",
                     "link": "https://en.wikipedia.org/wiki/Second_Chances_(Star_Trek:_The_Next_Generation)",
                     "director": "LeVar Burton",
-                    "air_date": "May 24, 1993"
+                    "air_date": "May 22, 1993"
                 },
                 {
                     "num_overall": "151",
@@ -1238,7 +1238,7 @@
                     "title": "Timescape",
                     "link": "https://en.wikipedia.org/wiki/Timescape_(Star_Trek:_The_Next_Generation)",
                     "director": "Adam Nimoy",
-                    "air_date": "June 14, 1993"
+                    "air_date": "June 12, 1993"
                 },
                 {
                     "num_overall": "152",
@@ -1246,7 +1246,7 @@
                     "title": "Descent, Part I",
                     "link": "https://en.wikipedia.org/wiki/Descent_(Star_Trek:_The_Next_Generation)",
                     "director": "Alexander Singer",
-                    "air_date": "June 21, 1993"
+                    "air_date": "June 19, 1993"
                 }
             ]
         },

--- a/output/star_trek_series_4_deep_space_nine_episodes.json
+++ b/output/star_trek_series_4_deep_space_nine_episodes.json
@@ -17,7 +17,7 @@
                     "num_overall": "2",
                     "num_in_season": "2",
                     "title": "Emissary",
-                    "link": "",
+                    "link": "https://en.wikipedia.org/wiki/Emissary_(Star_Trek:_Deep_Space_Nine)",
                     "director": "Emissary",
                     "air_date": "January 3, 1993"
                 },
@@ -614,7 +614,7 @@
                     "num_overall": "74",
                     "num_in_season": "2",
                     "title": "The Way of the Warrior",
-                    "link": "",
+                    "link": "https://en.wikipedia.org/wiki/The_Way_of_the_Warrior_(Star_Trek:_Deep_Space_Nine)",
                     "director": "James L. Conway",
                     "air_date": "September 30, 1995"
                 },
@@ -1451,7 +1451,7 @@
                     "num_overall": "176",
                     "num_in_season": "26",
                     "title": "What You Leave Behind",
-                    "link": "",
+                    "link": "https://en.wikipedia.org/wiki/What_You_Leave_Behind",
                     "director": "Allan Kroeker",
                     "air_date": "June 2, 1999"
                 }

--- a/output/star_trek_series_4_deep_space_nine_episodes.json
+++ b/output/star_trek_series_4_deep_space_nine_episodes.json
@@ -6,11 +6,19 @@
             "season_end": "June 19, 1993",
             "episodes": [
                 {
-                    "num_overall": "12",
-                    "num_in_season": "12",
+                    "num_overall": "1",
+                    "num_in_season": "1",
                     "title": "Emissary",
                     "link": "https://en.wikipedia.org/wiki/Emissary_(Star_Trek:_Deep_Space_Nine)",
                     "director": "David Carson",
+                    "air_date": "January 3, 1993"
+                },
+                {
+                    "num_overall": "2",
+                    "num_in_season": "2",
+                    "title": "Emissary",
+                    "link": "",
+                    "director": "Emissary",
                     "air_date": "January 3, 1993"
                 },
                 {
@@ -595,10 +603,18 @@
             "season_end": "June 15, 1996",
             "episodes": [
                 {
-                    "num_overall": "7374",
-                    "num_in_season": "12",
+                    "num_overall": "73",
+                    "num_in_season": "1",
                     "title": "The Way of the Warrior",
                     "link": "https://en.wikipedia.org/wiki/The_Way_of_the_Warrior_(Star_Trek:_Deep_Space_Nine)",
+                    "director": "James L. Conway",
+                    "air_date": "September 30, 1995"
+                },
+                {
+                    "num_overall": "74",
+                    "num_in_season": "2",
+                    "title": "The Way of the Warrior",
+                    "link": "",
                     "director": "James L. Conway",
                     "air_date": "September 30, 1995"
                 },
@@ -1022,7 +1038,7 @@
                     "title": "A Time to Stand",
                     "link": "https://en.wikipedia.org/wiki/A_Time_to_Stand",
                     "director": "Allan Kroeker",
-                    "air_date": "September 29, 1997"
+                    "air_date": "September 27, 1997"
                 },
                 {
                     "num_overall": "126",
@@ -1030,7 +1046,7 @@
                     "title": "Rocks and Shoals",
                     "link": "https://en.wikipedia.org/wiki/Rocks_and_Shoals_(Star_Trek:_Deep_Space_Nine)",
                     "director": "Mike Vejar",
-                    "air_date": "October 6, 1997"
+                    "air_date": "October 4, 1997"
                 },
                 {
                     "num_overall": "127",
@@ -1038,7 +1054,7 @@
                     "title": "Sons and Daughters",
                     "link": "https://en.wikipedia.org/wiki/Sons_and_Daughters_(Star_Trek:_Deep_Space_Nine)",
                     "director": "Jesús Salvador Treviño",
-                    "air_date": "October 13, 1997"
+                    "air_date": "October 11, 1997"
                 },
                 {
                     "num_overall": "128",
@@ -1046,7 +1062,7 @@
                     "title": "Behind the Lines",
                     "link": "https://en.wikipedia.org/wiki/Behind_the_Lines_(Star_Trek:_Deep_Space_Nine)",
                     "director": "LeVar Burton",
-                    "air_date": "October 20, 1997"
+                    "air_date": "October 18, 1997"
                 },
                 {
                     "num_overall": "129",
@@ -1054,7 +1070,7 @@
                     "title": "Favor the Bold",
                     "link": "https://en.wikipedia.org/wiki/Favor_the_Bold",
                     "director": "Winrich Kolbe",
-                    "air_date": "October 27, 1997"
+                    "air_date": "October 25, 1997"
                 },
                 {
                     "num_overall": "130",
@@ -1062,7 +1078,7 @@
                     "title": "Sacrifice of Angels",
                     "link": "https://en.wikipedia.org/wiki/Sacrifice_of_Angels",
                     "director": "Allan Kroeker",
-                    "air_date": "November 3, 1997"
+                    "air_date": "November 1, 1997"
                 },
                 {
                     "num_overall": "131",
@@ -1070,7 +1086,7 @@
                     "title": "You Are Cordially Invited",
                     "link": "https://en.wikipedia.org/wiki/You_Are_Cordially_Invited",
                     "director": "David Livingston",
-                    "air_date": "November 10, 1997"
+                    "air_date": "November 8, 1997"
                 },
                 {
                     "num_overall": "132",
@@ -1078,7 +1094,7 @@
                     "title": "Resurrection",
                     "link": "https://en.wikipedia.org/wiki/Resurrection_(Star_Trek:_Deep_Space_Nine)",
                     "director": "LeVar Burton",
-                    "air_date": "November 17, 1997"
+                    "air_date": "November 15, 1997"
                 },
                 {
                     "num_overall": "133",
@@ -1086,7 +1102,7 @@
                     "title": "Statistical Probabilities",
                     "link": "https://en.wikipedia.org/wiki/Statistical_Probabilities",
                     "director": "Anson Williams",
-                    "air_date": "November 24, 1997"
+                    "air_date": "November 22, 1997"
                 },
                 {
                     "num_overall": "134",
@@ -1094,7 +1110,7 @@
                     "title": "The Magnificent Ferengi",
                     "link": "https://en.wikipedia.org/wiki/The_Magnificent_Ferengi",
                     "director": "Chip Chalmers",
-                    "air_date": "December 29, 1997"
+                    "air_date": "December 27, 1997"
                 },
                 {
                     "num_overall": "135",
@@ -1102,7 +1118,7 @@
                     "title": "Waltz",
                     "link": "https://en.wikipedia.org/wiki/Waltz_(Star_Trek:_Deep_Space_Nine)",
                     "director": "René Auberjonois",
-                    "air_date": "January 5, 1998"
+                    "air_date": "January 3, 1998"
                 },
                 {
                     "num_overall": "136",
@@ -1110,7 +1126,7 @@
                     "title": "Who Mourns for Morn?",
                     "link": "https://en.wikipedia.org/wiki/Who_Mourns_for_Morn%3F",
                     "director": "Victor Lobl",
-                    "air_date": "February 2, 1998"
+                    "air_date": "January 31, 1998"
                 },
                 {
                     "num_overall": "137",
@@ -1118,7 +1134,7 @@
                     "title": "Far Beyond the Stars",
                     "link": "https://en.wikipedia.org/wiki/Far_Beyond_the_Stars",
                     "director": "Avery Brooks",
-                    "air_date": "February 9, 1998"
+                    "air_date": "February 7, 1998"
                 },
                 {
                     "num_overall": "138",
@@ -1126,7 +1142,7 @@
                     "title": "One Little Ship",
                     "link": "https://en.wikipedia.org/wiki/One_Little_Ship",
                     "director": "Allan Kroeker",
-                    "air_date": "February 16, 1998"
+                    "air_date": "February 14, 1998"
                 },
                 {
                     "num_overall": "139",
@@ -1134,7 +1150,7 @@
                     "title": "Honor Among Thieves",
                     "link": "https://en.wikipedia.org/wiki/Honor_Among_Thieves_(Star_Trek:_Deep_Space_Nine)",
                     "director": "Allan Eastman",
-                    "air_date": "February 23, 1998"
+                    "air_date": "February 21, 1998"
                 },
                 {
                     "num_overall": "140",
@@ -1142,7 +1158,7 @@
                     "title": "Change of Heart",
                     "link": "https://en.wikipedia.org/wiki/Change_of_Heart_(Star_Trek:_Deep_Space_Nine)",
                     "director": "David Livingston",
-                    "air_date": "March 2, 1998"
+                    "air_date": "February 28, 1998"
                 },
                 {
                     "num_overall": "141",
@@ -1150,7 +1166,7 @@
                     "title": "Wrongs Darker Than Death or Night",
                     "link": "https://en.wikipedia.org/wiki/Wrongs_Darker_Than_Death_or_Night",
                     "director": "Jonathan West",
-                    "air_date": "March 30, 1998"
+                    "air_date": "March 28, 1998"
                 },
                 {
                     "num_overall": "142",
@@ -1158,7 +1174,7 @@
                     "title": "Inquisition",
                     "link": "https://en.wikipedia.org/wiki/Inquisition_(Star_Trek:_Deep_Space_Nine)",
                     "director": "Michael Dorn",
-                    "air_date": "April 6, 1998"
+                    "air_date": "April 4, 1998"
                 },
                 {
                     "num_overall": "143",
@@ -1166,7 +1182,7 @@
                     "title": "In the Pale Moonlight",
                     "link": "https://en.wikipedia.org/wiki/In_the_Pale_Moonlight",
                     "director": "Victor Lobl",
-                    "air_date": "April 13, 1998"
+                    "air_date": "April 11, 1998"
                 },
                 {
                     "num_overall": "144",
@@ -1174,7 +1190,7 @@
                     "title": "His Way",
                     "link": "https://en.wikipedia.org/wiki/His_Way_(Star_Trek:_Deep_Space_Nine)",
                     "director": "Allan Kroeker",
-                    "air_date": "April 20, 1998"
+                    "air_date": "April 18, 1998"
                 },
                 {
                     "num_overall": "145",
@@ -1182,7 +1198,7 @@
                     "title": "The Reckoning",
                     "link": "https://en.wikipedia.org/wiki/The_Reckoning_(Star_Trek:_Deep_Space_Nine)",
                     "director": "Jesús Salvador Treviño",
-                    "air_date": "April 27, 1998"
+                    "air_date": "April 25, 1998"
                 },
                 {
                     "num_overall": "146",
@@ -1190,7 +1206,7 @@
                     "title": "Valiant",
                     "link": "https://en.wikipedia.org/wiki/Valiant_(Star_Trek:_Deep_Space_Nine)",
                     "director": "Mike Vejar",
-                    "air_date": "May 4, 1998"
+                    "air_date": "May 2, 1998"
                 },
                 {
                     "num_overall": "147",
@@ -1198,7 +1214,7 @@
                     "title": "Profit and Lace",
                     "link": "https://en.wikipedia.org/wiki/Profit_and_Lace",
                     "director": "Siddig El Faddil",
-                    "air_date": "May 11, 1998"
+                    "air_date": "May 9, 1998"
                 },
                 {
                     "num_overall": "148",
@@ -1206,7 +1222,7 @@
                     "title": "Time's Orphan",
                     "link": "https://en.wikipedia.org/wiki/Time%27s_Orphan",
                     "director": "Allan Kroeker",
-                    "air_date": "May 18, 1998"
+                    "air_date": "May 16, 1998"
                 },
                 {
                     "num_overall": "149",
@@ -1214,7 +1230,7 @@
                     "title": "The Sound of Her Voice",
                     "link": "https://en.wikipedia.org/wiki/The_Sound_of_Her_Voice",
                     "director": "Winrich Kolbe",
-                    "air_date": "June 8, 1998"
+                    "air_date": "June 6, 1998"
                 },
                 {
                     "num_overall": "150",
@@ -1222,7 +1238,7 @@
                     "title": "Tears of the Prophets",
                     "link": "https://en.wikipedia.org/wiki/Tears_of_the_Prophets",
                     "director": "Allan Kroeker",
-                    "air_date": "June 15, 1998"
+                    "air_date": "June 13, 1998"
                 }
             ]
         },
@@ -1424,10 +1440,18 @@
                     "air_date": "May 26, 1999"
                 },
                 {
-                    "num_overall": "175176",
-                    "num_in_season": "2526",
+                    "num_overall": "175",
+                    "num_in_season": "25",
                     "title": "What You Leave Behind",
                     "link": "https://en.wikipedia.org/wiki/What_You_Leave_Behind",
+                    "director": "Allan Kroeker",
+                    "air_date": "June 2, 1999"
+                },
+                {
+                    "num_overall": "176",
+                    "num_in_season": "26",
+                    "title": "What You Leave Behind",
+                    "link": "",
                     "director": "Allan Kroeker",
                     "air_date": "June 2, 1999"
                 }

--- a/output/star_trek_series_5_voyager_episodes.json
+++ b/output/star_trek_series_5_voyager_episodes.json
@@ -6,8 +6,16 @@
             "season_end": "May 22, 1995",
             "episodes": [
                 {
-                    "num_overall": "12",
-                    "num_in_season": "12",
+                    "num_overall": "1",
+                    "num_in_season": "1",
+                    "title": "Caretaker",
+                    "link": "https://en.wikipedia.org/wiki/Caretaker_(Star_Trek:_Voyager)",
+                    "director": "Winrich Kolbe",
+                    "air_date": "January 16, 1995"
+                },
+                {
+                    "num_overall": "2",
+                    "num_in_season": "2",
                     "title": "Caretaker",
                     "link": "https://en.wikipedia.org/wiki/Caretaker_(Star_Trek:_Voyager)",
                     "director": "Winrich Kolbe",
@@ -699,8 +707,16 @@
                     "air_date": "February 25, 1998"
                 },
                 {
-                    "num_overall": "8687",
-                    "num_in_season": "1819",
+                    "num_overall": "86",
+                    "num_in_season": "18",
+                    "title": "The Killing Game",
+                    "link": "https://en.wikipedia.org/wiki/The_Killing_Game_(Star_Trek:_Voyager)",
+                    "director": "David Livingston",
+                    "air_date": "March 4, 1998"
+                },
+                {
+                    "num_overall": "87",
+                    "num_in_season": "19",
                     "title": "The Killing Game",
                     "link": "https://en.wikipedia.org/wiki/The_Killing_Game_(Star_Trek:_Voyager)",
                     "director": "David Livingston",
@@ -882,12 +898,20 @@
                     "air_date": "February 10, 1999"
                 },
                 {
-                    "num_overall": "109110",
-                    "num_in_season": "1516",
+                    "num_overall": "109",
+                    "num_in_season": "15",
                     "title": "Dark Frontier",
                     "link": "https://en.wikipedia.org/wiki/Dark_Frontier",
-                    "director": "Cliff BoleTerry Windell",
+                    "director": "Cliff Bole",
                     "air_date": "February 17, 1999"
+                },
+                {
+                    "num_overall": "110",
+                    "num_in_season": "16",
+                    "title": "Dark Frontier",
+                    "link": "https://en.wikipedia.org/wiki/Dark_Frontier",
+                    "director": "Terry Windell",
+                    "air_date": "Terry Windell"
                 },
                 {
                     "num_overall": "111",
@@ -1256,12 +1280,20 @@
                     "air_date": "November 22, 2000"
                 },
                 {
-                    "num_overall": "155156",
-                    "num_in_season": "910",
+                    "num_overall": "155",
+                    "num_in_season": "9",
                     "title": "Flesh and Blood",
                     "link": "https://en.wikipedia.org/wiki/Flesh_and_Blood_(Star_Trek:_Voyager)",
-                    "director": "Mike VejarDavid Livingston",
+                    "director": "Mike Vejar",
                     "air_date": "November 29, 2000"
+                },
+                {
+                    "num_overall": "156",
+                    "num_in_season": "10",
+                    "title": "Flesh and Blood",
+                    "link": "https://en.wikipedia.org/wiki/Flesh_and_Blood_(Star_Trek:_Voyager)",
+                    "director": "David Livingston",
+                    "air_date": "Story by : Bryan Fuller and Raf GreenTeleplay by : Raf Green and Kenneth Biller"
                 },
                 {
                     "num_overall": "157",
@@ -1376,8 +1408,16 @@
                     "air_date": "May 16, 2001"
                 },
                 {
-                    "num_overall": "171172",
-                    "num_in_season": "2526",
+                    "num_overall": "171",
+                    "num_in_season": "25",
+                    "title": "Endgame",
+                    "link": "https://en.wikipedia.org/wiki/Endgame_(Star_Trek:_Voyager)",
+                    "director": "Allan Kroeker",
+                    "air_date": "May 23, 2001"
+                },
+                {
+                    "num_overall": "172",
+                    "num_in_season": "26",
                     "title": "Endgame",
                     "link": "https://en.wikipedia.org/wiki/Endgame_(Star_Trek:_Voyager)",
                     "director": "Allan Kroeker",

--- a/output/star_trek_series_7_discovery_episodes.json
+++ b/output/star_trek_series_7_discovery_episodes.json
@@ -327,7 +327,7 @@
                     "num_overall": "39",
                     "num_in_season": "10",
                     "title": "Terra Firma",
-                    "link": "",
+                    "link": "https://en.wikipedia.org/wiki/Terra_Firma_(Star_Trek:_Discovery)",
                     "director": "Chloe Domont",
                     "air_date": "December 17, 2020"
                 },

--- a/output/star_trek_series_9_picard_episodes.json
+++ b/output/star_trek_series_9_picard_episodes.json
@@ -80,9 +80,9 @@
                 {
                     "num_overall": "10",
                     "num_in_season": "10",
-                    "title": "Teleplay by : Michael ChabonStory by : Michael Chabon & Akiva Goldsman",
+                    "title": "Et in Arcadia Ego",
                     "link": "",
-                    "director": "March 26, 2020",
+                    "director": "Akiva Goldsman",
                     "air_date": "March 26, 2020"
                 }
             ]

--- a/output/star_trek_series_info.json
+++ b/output/star_trek_series_info.json
@@ -101,8 +101,8 @@
     "12": {
         "name": "Strange New Worlds",
         "url": "https://en.wikipedia.org/wiki/Star_Trek:_Strange_New_Worlds",
-        "season_count": "1",
-        "episode_count": "10",
+        "season_count": "2",
+        "episode_count": "20",
         "episodes_url": "https://en.wikipedia.org/wiki/Star_Trek:_Strange_New_Worlds",
         "dates": "May 5, 2022 - present",
         "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/98/Star_Trek_SNW_logo.svg/220px-Star_Trek_SNW_logo.svg.png"


### PR DESCRIPTION
Recent changes in the source Wikipedia data formatting have caused the script to crash (again).

These are changes to fix that. Some are a bit hacky right now, but a full refactor is planned once the script functions again.